### PR TITLE
RT #75933

### DIFF
--- a/lib/HTML/FillInForm.pm
+++ b/lib/HTML/FillInForm.pm
@@ -273,7 +273,7 @@ sub start {
     if (defined($value)){
       # check for input type, noting that default type is text
       if (!exists $attr->{'type'} ||
-	  $attr->{'type'} =~ /^(text|textfield|hidden|)$/i){
+	  $attr->{'type'} =~ /^(text|textfield|hidden|tel|search|url|email|datetime|date|month|week|time|datetime\-local|number|range|color|)$/i){
 	if ( ref($value) eq 'ARRAY' ) {
 	  $value = shift @$value;
 	  $value = '' unless defined $value;

--- a/t/27_html5.t
+++ b/t/27_html5.t
@@ -1,0 +1,37 @@
+use strict;
+use warnings FATAL => 'all';
+use Test::More;
+use HTML::FillInForm;
+
+# See http://www.w3.org/TR/html5/forms.html#the-input-element
+
+my %data = (
+  tel => '00-0000-0000',
+  search => 'search word',
+  url => 'http://localhost',
+  email => 'foo@example.com',
+  datetime => '2012-10-10T00:00Z',
+  date => '2012-10-10',
+  month => '2012-10',
+  week => '2012-W10',
+  time => '00:00',
+  'datetime-local' => '2012-10-10T00:00',
+  number => 1,
+  range => 10,
+  color => '#000000',
+);
+
+plan tests => scalar keys %data;
+
+my $html =
+  '<!doctype html><html><body><form>' .
+  (join '', map { qq/<input type="$_" name="$_">/ } keys %data) .
+  '</form></body></html>';
+
+
+my $result = HTML::FillInForm->new->fill(\$html, \%data);
+
+for my $key (keys %data) {
+  my ($input) = $result =~ /(<input[^>]+type="$key"[^>]*>)/;
+  like $input => qr/value="$data{$key}"/, "filled $key";
+}


### PR DESCRIPTION
- Added HTML5 input type attributes support
- Added a test for filling-in the missing HTML5 input type attributes

Mark also asked to update docs (https://rt.cpan.org/Public/Bug/Display.html?id=75933#txn-1230637), but apparently there's no section for other specs like HTML4. I'm not sure if a section for HTML5 is necessary.
