### PR TITLE
Patch bug #100926, compatibility with CGI 4 (with fallback).

### DIFF
--- a/lib/HTML/FillInForm.pm
+++ b/lib/HTML/FillInForm.pm
@@ -424,7 +424,12 @@ sub _get_param {
   # traverse the list in reverse order for backwards compatibility
   # with the previous implementation.
   for my $o (reverse @{$self->{objects}}) {
-    my @v = $o->param($param);
+    my @v;
+    if ($o->can('multi_param')) {
+      @v = $o->multi_param($param);
+    } else {
+      @v = $o->param($param);
+    }
 
     next unless @v;
 


### PR DESCRIPTION
Nabbed code from https://rt.cpan.org/Public/Bug/Display.html?id=100926 to avoid warnings with CGI 4. List context use looks safe here, as this code is assigning to an array, and not the security hazardous form, unless the "object_param_cache" item is somehow used unsafely, elsewhere. Tests pass w/o warnings.
